### PR TITLE
GH-32 Read access token directly from http request

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,12 +24,6 @@ object SpringBoot {
 object SpringSecurity {
     const val config = "org.springframework.security:spring-security-config:${Versions.spring}"
     const val web = "org.springframework.security:spring-security-web:${Versions.spring}"
-
-    object OAuth2 {
-        const val core = "org.springframework.security:spring-security-oauth2-core:${Versions.spring}"
-        const val legacy = "org.springframework.security.oauth:spring-security-oauth2:${Versions.legacySecurity}"
-    }
-
 }
 
 

--- a/opa-filter-core/build.gradle.kts
+++ b/opa-filter-core/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     api(Opa.client)
     implementation(Slf4j.api)
     implementation(SpringSecurity.web)
-    implementation(SpringSecurity.OAuth2.core)
-    implementation(SpringSecurity.OAuth2.legacy)
     implementation(Javax.servletApi)
 
     testImplementation(Testing.springTest)

--- a/opa-filter-core/src/main/java/com/bisnode/opa/spring/security/filter/decision/request/DefaultOpaRequestSupplier.java
+++ b/opa-filter-core/src/main/java/com/bisnode/opa/spring/security/filter/decision/request/DefaultOpaRequestSupplier.java
@@ -19,7 +19,7 @@ public class DefaultOpaRequestSupplier implements OpaRequestSupplier<OpaInput> {
         OpaInput.Builder inputBuilder = OpaInput.builder()
                 .method(request.getMethod())
                 .path(request.getServletPath());
-        Jwt.fromSecurityContext().map(Jwt::getEncoded).ifPresent(inputBuilder::encodedJwt);
+        Jwt.fromHttpRequest(request).map(Jwt::getEncoded).ifPresent(inputBuilder::encodedJwt);
         return inputBuilder.build();
     }
 }

--- a/opa-filter-core/src/test/groovy/com/bisnode/opa/spring/security/filter/decision/request/DefaultOpaRequestSupplierSpec.groovy
+++ b/opa-filter-core/src/test/groovy/com/bisnode/opa/spring/security/filter/decision/request/DefaultOpaRequestSupplierSpec.groovy
@@ -1,10 +1,6 @@
 package com.bisnode.opa.spring.security.filter.decision.request
 
 import org.springframework.mock.web.MockHttpServletRequest
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.context.SecurityContextImpl
-import org.springframework.security.oauth2.core.AbstractOAuth2Token
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -42,14 +38,9 @@ class DefaultOpaRequestSupplierSpec extends Specification {
     def 'should fill request with JWT when token is present'() {
         given:
             String token = 'some.token.withCrypto'
-            Authentication authentication = Stub() {
-                getCredentials() >> Stub(AbstractOAuth2Token) {
-                    getTokenValue() >> token
-                }
-            }
-            SecurityContextHolder.setContext(new SecurityContextImpl(authentication))
 
             HttpServletRequest httpServletRequest = new MockHttpServletRequest('GET', 'http://localhost:8080/test')
+            httpServletRequest.addHeader('Authorization', "Bearer $token")
 
         when:
             def input = defaultOpaRequestSupplier.get(httpServletRequest)


### PR DESCRIPTION
Read access token directly from http request instead of Spring Security context.
It's a part of use case to authorize http request in OPA before creating Spring Security context.