### PR TITLE
GH-34 Do not publish authorization failure event when…

### DIFF
--- a/opa-filter-core/src/main/java/com/bisnode/opa/spring/security/filter/OpaFilter.java
+++ b/opa-filter-core/src/main/java/com/bisnode/opa/spring/security/filter/OpaFilter.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class OpaFilter extends GenericFilterBean {
 
@@ -109,9 +110,9 @@ public class OpaFilter extends GenericFilterBean {
         String rejectionMessage = String.format("Access request rejected by OPA because: %s", accessDecision.getReason());
         log.debug(rejectionMessage);
         AccessDeniedException accessDeniedException = new AccessDeniedException(rejectionMessage);
-        AuthorizationFailureEvent event = new AuthorizationFailureEvent(
-                this, List.of(), SecurityContextHolder.getContext().getAuthentication(), accessDeniedException);
-        eventPublisher.publishEvent(event);
+        Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(authentication -> new AuthorizationFailureEvent(OpaFilter.this, List.of(), authentication, accessDeniedException))
+                .ifPresent(eventPublisher::publishEvent);
         throw accessDeniedException;
     }
 

--- a/opa-filter-core/src/test/groovy/com/bisnode/opa/spring/security/filter/OpaFilterSpec.groovy
+++ b/opa-filter-core/src/test/groovy/com/bisnode/opa/spring/security/filter/OpaFilterSpec.groovy
@@ -46,6 +46,23 @@ class OpaFilterSpec extends Specification {
           1 * eventPublisher.publishEvent(_ as AuthorizationFailureEvent)
     }
 
+    def 'should throw AccessDeniedException on disallow and not publish AuthorizationFailureEvent when security context without authentication'() {
+        given:
+          SecurityContextHolder.clearContext()
+          FilterChain filterChain = Mock()
+          HttpServletRequest httpServletRequest = Mock()
+          decider.decideFor(httpServletRequest) >> new AccessDecision(allow: false)
+          whitelistRequestMatcher.matches(_ as HttpServletRequest) >> false
+
+        when:
+          opaFilter.doFilter(httpServletRequest, null, filterChain)
+
+        then:
+          thrown AccessDeniedException
+          0 * filterChain.doFilter(_, _)
+          0 * eventPublisher.publishEvent(_ as AuthorizationFailureEvent)
+    }
+
     def 'should throw AccessDeniedException on undefined response'() {
         given:
             FilterChain filterChain = Mock()


### PR DESCRIPTION
Do not publish authorization failure event on access denied OPA output when security context without authentication.
It's a part of use case to authorize http request in OPA before creating Spring Security context.